### PR TITLE
Updated app-service-certificate and app-service deployment resources

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -87,6 +87,7 @@
       "condition": "[greater(length(parameters('customHostName')), 0)]",
       "apiVersion": "2017-05-10",
       "name": "app-service-certificate",
+      "resourceGroup": "[parameters('sharedFrontEndAppServicePlanResourceGroupName')]",
       "type": "Microsoft.Resources/deployments",
       "properties": {
         "mode": "Incremental",

--- a/azure/template.json
+++ b/azure/template.json
@@ -181,7 +181,10 @@
             "value": "[parameters('appServiceAllowedIPs')]"
           }
         }
-      }
+      },
+      "dependsOn": [
+        "app-service-certificate"
+      ]
     }
   ],
   "outputs": {


### PR DESCRIPTION
- Added the resource group parameter to the app-service-certificate deployment resource to use the shared front end app service plan resource group.
- Added a depends on to the app-service resource deployment to depend on the app-service-certificate deployment.