### PR TITLE
Web, API: Changed ping endpoint URLs from /health to /ping

### DIFF
--- a/azure/template.json
+++ b/azure/template.json
@@ -323,7 +323,7 @@
                 },
                 {
                   "name": "WEBSITE_SWAP_WARMUP_PING_PATH",
-                  "value": "/health"
+                  "value": "/ping"
                 },
                 {
                   "name": "WEBSITE_SWAP_WARMUP_PING_STATUSES",

--- a/src/SFA.DAS.DownloadService.Api/Startup.cs
+++ b/src/SFA.DAS.DownloadService.Api/Startup.cs
@@ -108,7 +108,7 @@ namespace SFA.DAS.DownloadService.Api
             app.UseStaticFiles();
             app.UseCookiePolicy();
             app.UseSession();
-            app.UseHealthChecks("/health");
+            app.UseHealthChecks("/ping");
             app.UseRequestLocalization();
 
 

--- a/src/SFA.DAS.DownloadService.Web/Startup.cs
+++ b/src/SFA.DAS.DownloadService.Web/Startup.cs
@@ -108,7 +108,7 @@ namespace SFA.DAS.DownloadService.Web
             app.UseStaticFiles();
             app.UseCookiePolicy();
             app.UseSession();
-            app.UseHealthChecks("/health");
+            app.UseHealthChecks("/ping");
             app.UseRequestLocalization();
 
             app.UseMvc(routes =>


### PR DESCRIPTION
Standardise to service standard of /ping for simple health check

https://github.com/SkillsFundingAgency/das-dotnet-templates/blob/bd0a77544d4ddeedd716eebbe2cc0bcf1378b604/src/working/templates/Web/src/SFA.DAS.WebTemplateSourceName.Web/StartupExtensions/HealthCheckStartupExtensions.cs#L25